### PR TITLE
Create CustomException.php

### DIFF
--- a/APIJet/ApiException.php
+++ b/APIJet/ApiException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Api;
+
+/**
+ * Api
+ * @package  APIJet
+ * @author   Pavel Tashev
+ * @since    1.0.0
+ *
+ */
+class ApiException extends \Exception
+{
+    private $_error_body;
+    private $_http_code;
+
+    public function __construct($http_code, $error_body, $message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->_error_body = $error_body;
+        $this->_http_code = $http_code;
+    }
+
+    public function getErrorBody() {
+        return $this->_error_body;
+    }
+
+    public function getHttpCode() {
+        return $this->_http_code;
+    }
+}

--- a/APIJet/ApiException.php
+++ b/APIJet/ApiException.php
@@ -11,21 +11,21 @@ namespace Api;
  */
 class ApiException extends \Exception
 {
-    private $_error_body;
-    private $_http_code;
+    private $error_body;
+    private $http_code;
 
     public function __construct($http_code, $error_body, $message = '', $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
-        $this->_error_body = $error_body;
-        $this->_http_code = $http_code;
+        $this->error_body = $error_body;
+        $this->http_code = $http_code;
     }
 
     public function getErrorBody() {
-        return $this->_error_body;
+        return $this->error_body;
     }
 
     public function getHttpCode() {
-        return $this->_http_code;
+        return $this->http_code;
     }
 }

--- a/APIJet/CustomException.php
+++ b/APIJet/CustomException.php
@@ -1,15 +1,13 @@
 <?php
 
-namespace Api;
+namespace APIJet;
 
 /**
- * Api
  * @package  APIJet
  * @author   Pavel Tashev
  * @since    1.0.0
- *
  */
-class ApiException extends \Exception
+class CustomException extends \Exception
 {
     private $error_body;
     private $http_code;


### PR DESCRIPTION
ApiException class allows us to create a custom error message. The body of the message can be a string or object. Also the class allows us to set the Http code.

This will save a lot of code when someone writes a new controller and methods.

Please take into account that this change is connected to a change proposed for APIJet.php method run()!
