### PR TITLE
Get the header by key

### DIFF
--- a/APIJet/Request.php
+++ b/APIJet/Request.php
@@ -38,6 +38,12 @@ class Request
         return substr($clearnRequestUrl, 1);
     }
     
+    public static function getHeader($key)
+    {
+        $headers = getallheaders();
+        return $headers[$key];
+    }
+    
     public static function getMethod()
     {
         return $_SERVER['REQUEST_METHOD'];


### PR DESCRIPTION
An example usage of method getHeader is when we use oAuth2 protocol. 

For the authentication process, oAuth2 requires a header of the following type (this is just an example) :

Authorization: Basic 7ed152c770ca72afbca6e776dd86ebbdec855c30898f276bf9dde054192aada2fdbc38ded59231edca17536aa434e0275c1b

This requires the API to provide us with a simple tool to extract the header by key. In our case the key is "Authorization". For more info about the oAuth2 protocol:

https://tools.ietf.org/html/rfc6749
