### PR TITLE
Fix for the native PHP function getallheaders

### DIFF
--- a/APIJet/Request.php
+++ b/APIJet/Request.php
@@ -40,7 +40,7 @@ class Request
     
     public static function getHeader($key)
     {
-        return getallheaders()[$key];
+        return self::getallheaders()[$key];
     }
     
     public static function getMethod()
@@ -96,5 +96,22 @@ class Request
             self::$inputData = $inputData;
         }
         return self::$inputData;
+    }
+    
+    /**
+     * @desc Get all headers
+     * @return array
+     */
+    private static function getallheaders()
+    {
+        $headers = array();
+        foreach ($_SERVER as $name => $value)
+        {
+            if (substr($name, 0, 5) == 'HTTP_')
+            {
+                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            }
+        }
+        return $headers;
     }
 }


### PR DESCRIPTION
Here we provide an alternative for the native PHP function getallheaders, because there are cases when it does not work.
